### PR TITLE
Add generic URL handling system for servers that don't support the TTVLOL API

### DIFF
--- a/streamlink-ttvlol.patch
+++ b/streamlink-ttvlol.patch
@@ -1,5 +1,5 @@
 diff --git a/src/streamlink/plugins/twitch.py b/src/streamlink/plugins/twitch.py
-index 8cb647fa..df7ac397 100644
+index 8cb647fa..630eaff3 100644
 --- a/src/streamlink/plugins/twitch.py
 +++ b/src/streamlink/plugins/twitch.py
 @@ -14,7 +14,7 @@ import sys
@@ -7,7 +7,7 @@ index 8cb647fa..df7ac397 100644
  from random import random
  from typing import List, NamedTuple, Optional
 -from urllib.parse import urlparse
-+from urllib.parse import urlparse, urlencode, quote
++from urllib.parse import urlparse, quote
  
  from streamlink.exceptions import NoStreamsError, PluginError
  from streamlink.plugin import Plugin, pluginargument, pluginmatcher
@@ -20,7 +20,7 @@ index 8cb647fa..df7ac397 100644
  from streamlink.utils.parse import parse_json, parse_qsd
  from streamlink.utils.times import hours_minutes_seconds
  from streamlink.utils.url import update_qsd
-@@ -208,6 +208,52 @@ class TwitchHLSStream(HLSStream):
+@@ -208,6 +208,51 @@ class TwitchHLSStream(HLSStream):
          self.low_latency = self.session.get_plugin_option("twitch", "low-latency")
  
  
@@ -39,8 +39,7 @@ index 8cb647fa..df7ac397 100644
 +        if not isinstance(self.excluded_channels, list):
 +            self.excluded_channels = [self.excluded_channels]
 +
-+    def _create_url(self, base, endpoint):
-+        url = base + endpoint
++    def _append_url_params(self, url):
 +        params = {
 +            "player": "twitchweb",
 +            "type": "any",
@@ -50,22 +49,22 @@ index 8cb647fa..df7ac397 100644
 +            "fast_bread": "true",
 +        }
 +
-+        encoded_url = quote(url + '?' + urlencode(params), safe=':/')
-+        req = self.session.http.prepare_new_request(url=encoded_url)
++        req = self.session.http.prepare_new_request(url=url, params=params)
 +
 +        return req.url
 +
 +    def channel(self, channel):
 +        urls = []
++
 +        for proxy in self.playlist_proxies:
++            url = re.sub(r"\[channel\]", channel, proxy)
 +
-+            #Official Purple Adblock servers
-+            #TODO: reduce spaghetti
-+            if "jupter.ga" in proxy:
-+                urls.append(proxy + f"/channel/{channel}")
-+                continue
++            if url != proxy:
++                url = self._append_url_params(url)
++            else:
++                url = quote(self._append_url_params(url + f"/playlist/{channel}.m3u8"), safe=":/")
 +
-+            urls.append(self._create_url(proxy, f"/playlist/{channel}.m3u8"))
++            urls.append(url)
 +
 +        return urls
 +
@@ -73,7 +72,7 @@ index 8cb647fa..df7ac397 100644
  class UsherService:
      def __init__(self, session):
          self.session = session
-@@ -568,6 +614,42 @@ class TwitchAPI:
+@@ -568,6 +613,42 @@ class TwitchAPI:
          Can be repeated to add multiple parameters.
      """,
  )
@@ -88,7 +87,7 @@ index 8cb647fa..df7ac397 100644
 +
 +        Only livestreams will use the playlist proxy, VODs and clips will use upstream behavior.
 +
-+        When enabled the Twitch GraphQL API will not be called.
++        When used the Twitch GraphQL API will not be called.
 +        --twitch-api-header and --twitch-access-token-param will have no effect.
 +        It will also not be possible to check for subscriber only streams and reruns will be disabled.
 +    """,
@@ -116,7 +115,7 @@ index 8cb647fa..df7ac397 100644
  class Twitch(Plugin):
      @classmethod
      def stream_weight(cls, stream):
-@@ -601,6 +683,7 @@ class Twitch(Plugin):
+@@ -601,6 +682,7 @@ class Twitch(Plugin):
  
          self.api = TwitchAPI(session=self.session)
          self.usher = UsherService(session=self.session)
@@ -124,7 +123,7 @@ index 8cb647fa..df7ac397 100644
  
          def method_factory(parent_method):
              def inner():
-@@ -676,6 +759,19 @@ class Twitch(Plugin):
+@@ -676,6 +758,19 @@ class Twitch(Plugin):
  
          return self._get_hls_streams(url, restricted_bitrates)
  
@@ -144,7 +143,7 @@ index 8cb647fa..df7ac397 100644
      def _get_hls_streams_video(self):
          log.debug(f"Getting HLS streams for video ID {self.video_id}")
          sig, token, restricted_bitrates = self._access_token(False, self.video_id)
-@@ -707,6 +803,18 @@ class Twitch(Plugin):
+@@ -707,6 +802,19 @@ class Twitch(Plugin):
  
          return streams
  
@@ -152,6 +151,7 @@ index 8cb647fa..df7ac397 100644
 +        for url in urls:
 +            parsed_url = urlparse(url)
 +            log.info(f"Using playlist proxy '{parsed_url.scheme}://{parsed_url.netloc}'")
++            log.debug(f"Raw playlist proxy URL: {url}")
 +
 +            try:
 +                return TwitchHLSStream.parse_variant_playlist(self.session, url)


### PR DESCRIPTION
Instead of supporting each API individually allow passing a custom URL. If the URL includes "[channel]" it will be replaced with the real channel name similar to the Xtra app, otherwise defaults to the TTVLOL API. It should work as long as the API doesn't require something like a custom header or URL encoding (TTVLOL).

Tested with Purple Adblock: --twitch-proxy-playlist="https://eu1.jupter.ga/channel/[channel]" and luminous native API: --twitch-proxy-playlist="https://eu.luminous.dev/live/[channel]"